### PR TITLE
Add metric: data_column_sidecars_submitted_for_processing

### DIFF
--- a/fork_choice_control/src/tasks.rs
+++ b/fork_choice_control/src/tasks.rs
@@ -399,6 +399,8 @@ impl<P: Preset, W> Run for DataColumnSidecarTask<P, W> {
                 .as_ref()
                 .map(|metrics| metrics.data_column_sidecar_verification_times.start_timer());
 
+            metrics.data_column_sidecars_submitted_for_processing.inc();
+
             let _timer = metrics
                 .as_ref()
                 .map(|metrics| metrics.fc_data_column_sidecar_task_times.start_timer());


### PR DESCRIPTION
`data_column_sidecars_submitted_for_processing` metric was not being used in the code. 
This PR will increment `data_column_sidecars_submitted_for_processing` in `DataColumnSidecarTask` prior to validating the data column sidecar. 